### PR TITLE
Update deployment source to BHPSModulePath

### DIFF
--- a/Wunderlist.psdeploy.ps1
+++ b/Wunderlist.psdeploy.ps1
@@ -15,7 +15,7 @@
 
 # Publish to gallery with a few restrictions
 if(
-    $env:BHProjectName -and $env:BHProjectName.Count -eq 1 -and
+    $env:BHPSModulePath -and
     $env:BHBuildSystem -ne 'Unknown' -and
     $env:BHBranchName -eq "master" -and
     $env:BHCommitMessage -match '!deploy'
@@ -23,7 +23,7 @@ if(
 {
     Deploy Module {
         By PSGalleryModule {
-            FromSource $ENV:BHProjectName
+            FromSource $ENV:BHPSModulePath
             To PSGallery
             WithOptions @{
                 ApiKey = $ENV:NugetApiKey
@@ -42,13 +42,13 @@ else
 
 # Publish to AppVeyor if we're in AppVeyor
 if(
-    $env:BHProjectName -and $ENV:BHProjectName.Count -eq 1 -and
+    $env:BHPSModulePath -and
     $env:BHBuildSystem -eq 'AppVeyor'
    )
 {
     Deploy DeveloperBuild {
         By AppVeyorModule {
-            FromSource $ENV:BHProjectName
+            FromSource $ENV:BHPSModulePath
             To AppVeyor
             WithOptions @{
                 Version = $env:APPVEYOR_BUILD_VERSION


### PR DESCRIPTION
Hi Stefan!

Here's an example of using the new BHPSModulePath as the source for the module.

This is an absolute path to the module.  The previous BHProjectName source relied on a very specific folder structure to get the relative path to your module.  BHPSModulePath is compatible with several common folder structures for a PowerShell module project on GitHub.

Cheers!

Warren
